### PR TITLE
Extend Travic CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,22 @@ addons:
   apt:
     sources: &sources
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.6
-      - llvm-toolchain-precise-3.7
-      - llvm-toolchain-precise-3.8
-      - llvm-toolchain-precise
+      - llvm-toolchain-trusty
+      - llvm-toolchain-trusty-3.9
+      - llvm-toolchain-trusty-4.0
+      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-6.0
     packages:
       - g++-4.9
+      - g++-5
+      - g++-6
+      - g++-7
 
 env:
   - CCOMPILER="gcc-4.9" CXXCOMPILER="g++-4.9"
+  - CCOMPILER="gcc-5" CXXCOMPILER="g++-5"
+  - CCOMPILER="gcc-6" CXXCOMPILER="g++-6"
+  - CCOMPILER="gcc-7" CXXCOMPILER="g++-7"
 
 # additional compilers  
 matrix:
@@ -37,6 +44,30 @@ matrix:
       addons:
         apt:
           packages: clang-3.8
+          sources: *sources
+    
+    - env: CCOMPILER="clang-3.9" CXXCOMPILER="clang++-3.9"
+      addons:
+        apt:
+          packages: clang-3.9
+          sources: *sources
+
+    - env: CCOMPILER="clang-4.0" CXXCOMPILER="clang++-4.0"
+      addons:
+        apt:
+          packages: clang-4.0
+          sources: *sources
+
+    - env: CCOMPILER="clang-5.0" CXXCOMPILER="clang++-5.0"
+      addons:
+        apt:
+          packages: clang-5.0
+          sources: *sources
+
+    - env: CCOMPILER="clang-6.0" CXXCOMPILER="clang++-6.0"
+      addons:
+        apt:
+          packages: clang-6.0
           sources: *sources
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,6 @@ matrix:
           packages: clang-3.6
           sources: *sources
 
-    - env: CCOMPILER="clang-3.7" CXXCOMPILER="clang++-3.7"
-      addons:
-        apt:
-          packages: clang-3.7
-          sources: *sources
-
     - env: CCOMPILER="clang-3.8" CXXCOMPILER="clang++-3.8"
       addons:
         apt:

--- a/include/cache.hpp
+++ b/include/cache.hpp
@@ -2,7 +2,9 @@
 #define CACHE_HPP
 
 #include "cache_policy.hpp"
+
 #include <cstddef>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Add:
 - gcc 4.9 - 7
 - clang 3.6 - 6.0