### PR TITLE
Fix issue #10

### DIFF
--- a/include/cache.hpp
+++ b/include/cache.hpp
@@ -49,7 +49,7 @@ class fixed_sized_cache
         if (elem_it == cache_items_map.end())
         {
             // add new element to the cache
-            if (Size() + 1 > max_cache_size)
+            if (cache_items_map.size() + 1 > max_cache_size)
             {
                 auto disp_candidate_key = cache_policy.ReplCandidate();
 

--- a/include/cache.hpp
+++ b/include/cache.hpp
@@ -43,7 +43,7 @@ class fixed_sized_cache
 
     void Put(const Key &key, const Value &value)
     {
-        operation_guard{safe_op};
+        operation_guard lock{safe_op};
         auto elem_it = FindElem(key);
 
         if (elem_it == cache_items_map.end())
@@ -67,7 +67,7 @@ class fixed_sized_cache
 
     const Value &Get(const Key &key) const
     {
-        operation_guard{safe_op};
+        operation_guard lock{safe_op};
         auto elem_it = FindElem(key);
 
         if (elem_it == cache_items_map.end())
@@ -81,20 +81,20 @@ class fixed_sized_cache
 
     bool Cached(const Key &key) const
     {
-        operation_guard{safe_op};
+        operation_guard lock{safe_op};
         return FindElem(key) != cache_items_map.end();
     }
 
     size_t Size() const
     {
-        operation_guard{safe_op};
+        operation_guard lock{safe_op};
 
         return cache_items_map.size();
     }
 
     void Clear()
     {
-        operation_guard{safe_op};
+        operation_guard lock{safe_op};
 
         for (auto it = begin(); it != end(); ++it)
         {


### PR DESCRIPTION
According to the #10 there were several issues with cache implementation:
 - no operation locking due to anonymous lock creation
 - double lock during `Put()` call due to `Size()` method call

Now it should be fixed