### PR TITLE
Include license file in conan package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class CacheConan(ConanFile):
     name = "cache"
     version = "0.0.4"
-    license = "BSD 3-Clause License"
+    license = "BSD-3-Clause"
     author = "Vladimir Petrigo <And your email here>"
     url = "https://github.com/vpetrigo/caches"
     description = "C++ LRU/FIFO/LFU Cache implementation"
@@ -22,6 +22,7 @@ class CacheConan(ConanFile):
 
     def package(self):
         self.copy("*.hpp")
+        self.copy("LICENSE.md", dst="licenses")
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Thank you for providing this library under an open source license. I'd like to suggest a couple of minor tweaks to the conanfile to assist automated builds to attribute your work.

I changed the `license` property of the package to `BSD-3-Clause` which is the [SPDX identifier](https://spdx.org/licenses/BSD-3-Clause.html) for the license ([conan docs reference](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#license)). And include the LICENSE.md file as part of the package in the "licenses" folder.

Thanks again!