### PR TITLE
Fix LRU policy Erase operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(caches
-        VERSION 0.1.0)
+        VERSION 0.1.1)
 
 macro(add_coverage_flags target)
     if (CACHES_BUILD_TEST AND CACHES_ENABLE_COVERAGE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ init:
   - git config --global core.autocrlf input
 
 os:
- - Visual Studio 2015
- - Visual Studio 2017
- - Visual Studio 2019
+  - Visual Studio 2017
+  - Visual Studio 2019
+  - Visual Studio 2022
 
 platform:
   - Win32
@@ -21,15 +21,15 @@ configuration:
 before_build:
   - git submodule update --init --recursive
   - mkdir build
-  - IF "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" ( SET GEN="Visual Studio 14 2015" )
   - IF "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" ( SET GEN="Visual Studio 15 2017" )
   - IF "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2019" ( SET GEN="Visual Studio 16 2019" )
-  - IF %PLATFORM% == "x64" IF NOT "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2019" ( SET GEN=%GEN% Win64 )
+  - IF "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2022" ( SET GEN="Visual Studio 17 2022" )
+  - IF %PLATFORM% == "x64" IF NOT "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2019" IF NOT "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2022" ( SET GEN=%GEN% Win64 )
   - cd build
-  - IF NOT "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2019" (
-      cmake .. -G%GEN%
+  - IF NOT "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2019" IF NOT "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2022" (
+    cmake .. -G%GEN%
     ) ELSE (
-      cmake .. -G %GEN% -A %PLATFORM%
+    cmake .. -G %GEN% -A %PLATFORM%
     )
 
 build_script:

--- a/include/caches/fifo_cache_policy.hpp
+++ b/include/caches/fifo_cache_policy.hpp
@@ -38,7 +38,7 @@ class FIFOCachePolicy : public ICachePolicy<Key>
     using fifo_iterator = typename std::list<Key>::const_iterator;
 
     FIFOCachePolicy() = default;
-    ~FIFOCachePolicy() = default;
+    ~FIFOCachePolicy() override = default;
 
     void Insert(const Key &key) override
     {

--- a/include/caches/lru_cache_policy.hpp
+++ b/include/caches/lru_cache_policy.hpp
@@ -40,7 +40,7 @@ class LRUCachePolicy : public ICachePolicy<Key>
     using lru_iterator = typename std::list<Key>::iterator;
 
     LRUCachePolicy() = default;
-    ~LRUCachePolicy() = default;
+    ~LRUCachePolicy() override = default;
 
     void Insert(const Key &key) override
     {
@@ -54,11 +54,11 @@ class LRUCachePolicy : public ICachePolicy<Key>
         lru_queue.splice(lru_queue.begin(), lru_queue, key_finder[key]);
     }
 
-    void Erase(const Key &) noexcept override
+    void Erase(const Key &key) noexcept override
     {
         // remove the least recently used element
-        key_finder.erase(lru_queue.back());
-        lru_queue.pop_back();
+        lru_queue.erase(key_finder[key]);
+        key_finder.erase(key);
     }
 
     // return a key of a displacement candidate

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,3 +28,6 @@ add_cache_test(lru_cache)
 add_cache_test(fifo_cache)
 add_cache_test(lfu_cache)
 add_cache_test(nopolicy_cache)
+
+add_executable(issue issue.cpp)
+target_link_libraries(issue PRIVATE caches)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,3 @@ add_cache_test(lru_cache)
 add_cache_test(fifo_cache)
 add_cache_test(lfu_cache)
 add_cache_test(nopolicy_cache)
-
-add_executable(issue issue.cpp)
-target_link_libraries(issue PRIVATE caches)

--- a/test/fifo_cache_tests.cpp
+++ b/test/fifo_cache_tests.cpp
@@ -6,6 +6,8 @@
 #include <parallel_hashmap/phmap.h>
 #endif /* CUSTOM_HASHMAP */
 
+#include <array>
+
 #ifndef CUSTOM_HASHMAP
 template <typename Key, typename Value>
 using fifo_cache_t = typename caches::fixed_sized_cache<Key, Value, caches::FIFOCachePolicy>;

--- a/test/fifo_cache_tests.cpp
+++ b/test/fifo_cache_tests.cpp
@@ -114,6 +114,52 @@ TEST(FIFOCache, Remove_Test)
     }
 }
 
+TEST(FIFOCache, Partial_Remove_Test)
+{
+    fifo_cache_t<std::string, int> cache{5};
+
+    for (int i = 0; i < 5; ++i)
+    {
+        cache.Put("key" + std::to_string(i), i);
+    }
+
+    constexpr std::array access_order = {
+        "key1", "key3", "key0", "key4", "key2",
+    };
+
+    for (const auto &key : access_order)
+    {
+        EXPECT_NE(cache.Get(key), nullptr);
+    }
+
+    cache.Remove("key3");
+
+    for (int i = 0; i < 5; ++i)
+    {
+        if (const auto key = "key" + std::to_string(i); key != "key3")
+        {
+            EXPECT_TRUE(cache.Cached(key));
+        }
+        else
+        {
+            EXPECT_FALSE(cache.Cached(key));
+        }
+    }
+
+    cache.Put("key5", 5);
+    cache.Put("key6", 6);
+
+    constexpr std::array access_order3 = {
+        "key5", "key6", "key1", "key2", "key4",
+    };
+
+    for (const auto &key : access_order3)
+    {
+        EXPECT_TRUE(cache.Cached(key));
+        EXPECT_NO_THROW(cache.Get(key));
+    }
+}
+
 TEST(FIFOCache, TryGet)
 {
     constexpr std::size_t TEST_CASE{10};

--- a/test/lfu_cache_tests.cpp
+++ b/test/lfu_cache_tests.cpp
@@ -16,6 +16,8 @@ using lfu_cache_t =
                                        phmap::node_hash_map<Key, caches::WrappedValue<Value>>>;
 #endif /* CUSTOM_HASHMAP */
 
+#include <array>
+
 TEST(LFUCache, Simple_Test)
 {
     constexpr size_t FIRST_FREQ = 10;

--- a/test/lfu_cache_tests.cpp
+++ b/test/lfu_cache_tests.cpp
@@ -129,6 +129,52 @@ TEST(LFUCache, Remove_Test)
     }
 }
 
+TEST(LFUCache, Partial_Remove_Test)
+{
+    lfu_cache_t<std::string, int> cache{5};
+
+    for (int i = 0; i < 5; ++i)
+    {
+        cache.Put("key" + std::to_string(i), i);
+    }
+
+    constexpr std::array access_order = {
+        "key1", "key3", "key0", "key4", "key2",
+    };
+
+    for (const auto &key : access_order)
+    {
+        EXPECT_NE(cache.Get(key), nullptr);
+    }
+
+    cache.Remove("key3");
+
+    for (int i = 0; i < 5; ++i)
+    {
+        if (const auto key = "key" + std::to_string(i); key != "key3")
+        {
+            EXPECT_TRUE(cache.Cached(key));
+        }
+        else
+        {
+            EXPECT_FALSE(cache.Cached(key));
+        }
+    }
+
+    cache.Put("key5", 5);
+    cache.Put("key6", 6);
+
+    constexpr std::array access_order3 = {
+        "key0", "key6", "key1", "key4", "key2",
+    };
+
+    for (const auto &key : access_order3)
+    {
+        EXPECT_TRUE(cache.Cached(key));
+        EXPECT_NO_THROW(cache.Get(key));
+    }
+}
+
 TEST(LFUCache, TryGet)
 {
     constexpr std::size_t TEST_CASE{10};

--- a/test/lru_cache_tests.cpp
+++ b/test/lru_cache_tests.cpp
@@ -16,6 +16,8 @@ using lru_cache_t =
                                        phmap::node_hash_map<Key, caches::WrappedValue<Value>>>;
 #endif /* CUSTOM_HASHMAP */
 
+#include <array>
+
 TEST(CacheTest, SimplePut)
 {
     lru_cache_t<std::string, int> cache(1);

--- a/test/lru_cache_tests.cpp
+++ b/test/lru_cache_tests.cpp
@@ -11,8 +11,9 @@ template <typename Key, typename Value>
 using lru_cache_t = typename caches::fixed_sized_cache<Key, Value, caches::LRUCachePolicy>;
 #else
 template <typename Key, typename Value>
-using lru_cache_t = typename caches::fixed_sized_cache<Key, Value, caches::LRUCachePolicy,
-                                                       phmap::node_hash_map<Key, caches::WrappedValue<Value>>>;
+using lru_cache_t =
+    typename caches::fixed_sized_cache<Key, Value, caches::LRUCachePolicy,
+                                       phmap::node_hash_map<Key, caches::WrappedValue<Value>>>;
 #endif /* CUSTOM_HASHMAP */
 
 TEST(CacheTest, SimplePut)
@@ -101,6 +102,52 @@ TEST(LRUCache, Remove_Test)
     }
 }
 
+TEST(LRUCache, Partial_Remove_Test)
+{
+    lru_cache_t<std::string, int> cache{5};
+
+    for (int i = 0; i < 5; ++i)
+    {
+        cache.Put("key" + std::to_string(i), i);
+    }
+
+    constexpr std::array access_order = {
+        "key1", "key3", "key0", "key4", "key2",
+    };
+
+    for (const auto &key : access_order)
+    {
+        EXPECT_NE(cache.Get(key), nullptr);
+    }
+
+    cache.Remove("key3");
+
+    for (int i = 0; i < 5; ++i)
+    {
+        if (const auto key = "key" + std::to_string(i); key != "key3")
+        {
+            EXPECT_TRUE(cache.Cached(key));
+        }
+        else
+        {
+            EXPECT_FALSE(cache.Cached(key));
+        }
+    }
+
+    cache.Put("key5", 5);
+    cache.Put("key6", 6);
+
+    constexpr std::array access_order3 = {
+        "key5", "key6", "key0", "key2", "key4",
+    };
+
+    for (const auto &key : access_order3)
+    {
+        EXPECT_TRUE(cache.Cached(key));
+        EXPECT_NO_THROW(cache.Get(key));
+    }
+}
+
 TEST(LRUCache, CachedCheck)
 {
     constexpr std::size_t TEST_SUITE = 4;
@@ -169,10 +216,12 @@ TEST(LRUCache, GetWithReplacement)
 
     std::string replaced_key;
 
-    for (size_t i = 1; i <= 2; ++i) {
+    for (size_t i = 1; i <= 2; ++i)
+    {
         const auto key = std::to_string(i);
 
-        if (!cache.Cached(key)) {
+        if (!cache.Cached(key))
+        {
             replaced_key = key;
         }
     }


### PR DESCRIPTION
Updated:
- LRU policy `Erase()` method to properly use found element iterator to remove it from the LRU replace candidate queue

Fixes #41 